### PR TITLE
Run `esy solve` before `esy fetch`

### DIFF
--- a/esy-docker.mk
+++ b/esy-docker.mk
@@ -92,6 +92,7 @@ const lines = [
   'WORKDIR /app',
   'COPY package.json package.json',
   'COPY esy.lock esy.lock',
+  'RUN esy solve',
   'RUN esy fetch',
   ...build,
   'COPY . .',


### PR DESCRIPTION
This is apparently needed otherwise I'm getting this error:

```
info fetch 0.4.3
error: no lock found, run 'esy solve' first

esy: exiting due to errors above
```