### PR TITLE
Add 'esyd' wrapper generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,28 @@ builder container and then copy over needed build artifacts from there:
     COPY --from=builder /app/_esy/default/build/install /app
     RUN /app/bin/myapp.exe
 
+### Generating `esyd` wrapper
+
+`esy-docker` can generate `esyd` command wrapper for `esy` which executes
+commands inside esy environment inside docker.
+
+It also mounts `$PWD/.docker/store` as local project store in docker and thus
+`./esyd build` will perform an incremental builds.
+
+Run:
+
+    % make esyd
+
+which will generate `./esyd` bash script which can be used further with:
+
+    % ./esyd build
+    % ./esyd x hello
+
+and so on.
+
+Note that if you change your project dependencies you need to regenerate `esyd`
+script by executing `make esyd` again.
+
 ## Further Work
 
 - Configure `esy-docker.mk` so that an app builder image can be tagged:


### PR DESCRIPTION
This adds generation of `esyd` command wrapper which allows to execute
commands directly inside esy's environment inside docker:

    % make esyd

Then:

    % ./esyd build
    % ./esyd x Cmd.exe

It also mounts `.docker/store` as `_esy/default/store` and thus allows
to perform incremental builds inside docker container.

Note that after changing project dependencies one needs to regenerate
`esyd` command wrapper by calling:

    % make esyd

again.